### PR TITLE
Update Romana to use v2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This cluster bootstraps 3 etcd nodes, 3 kubernetes masters and 3 kubernetes node
 | Name | Version |
 |:-----|:-------:|
 | [kubernetes](https://github.com/kubernetes/kubernetes) (all components) | 1.9.0-alpha.2 |
-| [romana](http://romana.io/) (cni) | 2.0-preview.3b |
+| [romana](http://romana.io/) (cni) | v2.0 |
 | [kube-dns](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/dns) (dns) | 1.14.4 |
 | [influxdb](https://www.influxdata.com/) (monitoring) | 1.3.3 |
 | [heapster](https://github.com/kubernetes/heapster) (monitoring) | 1.4.0 |

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -59,7 +59,7 @@ kubernetes:
     version: "0.6.0"
   romana:
     # the version of romana to use
-    version: "2.0-preview.3b"
+    version: "2.0.0"
 
     # since we're using 3 hosts, this will make:
     # first IP: 10.200.0.0


### PR DESCRIPTION
Originally built with a preview release of Romana. Since then, Romana v2.0 has gone GA. Only bug fixes from preview to GA images. Details [here](http://romana.io/blog/romana-v2/).